### PR TITLE
Issue 1 - extract grid in use to new control - Fixed

### DIFF
--- a/MyMusic.Wpf/Controls/Player.xaml
+++ b/MyMusic.Wpf/Controls/Player.xaml
@@ -20,5 +20,6 @@
                 <TextBlock Text="{Binding CurrentTrack.Album}" FontSize="16pt"/>
             </StackPanel>
         </StackPanel>
-    </Grid>
+		<local:Playlist x:Name="playlistControl" Mp3FileSelected="playlistControl_Mp3FileSelected" Grid.Row="1" CurrentTrack="{Binding CurrentTrack}" Mp3Files="{Binding Playlist}"/>
+	</Grid>
 </UserControl>

--- a/MyMusic.Wpf/Controls/Player.xaml.cs
+++ b/MyMusic.Wpf/Controls/Player.xaml.cs
@@ -23,7 +23,7 @@ namespace MyMusic.Wpf.Controls
         public Player()
         {
             InitializeComponent();
-            DataContext = this;
+            DataContext = this;            
 
             _player = new MediaPlayer();
             _player.MediaEnded += player_MediaEnded;
@@ -58,7 +58,12 @@ namespace MyMusic.Wpf.Controls
         public void PlayNow(Mp3File file)
         {
             _track = 0;
-            _playlist.Insert(0, file);
+            if (!_playlist.Contains(file))
+                _playlist.Insert(0, file);
+            else
+            {
+                CurrentTrack = file;
+            }
         }
 
         public void PlayNext(Mp3File file) => _playlist.Insert(1, file);
@@ -81,6 +86,11 @@ namespace MyMusic.Wpf.Controls
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentTrack)));
                 }
             }
+        }
+
+        private void playlistControl_Mp3FileSelected(Mp3File mp3file)
+        {
+            PlayNow(mp3file);
         }
     }
 }

--- a/MyMusic.Wpf/Controls/Playlist.xaml
+++ b/MyMusic.Wpf/Controls/Playlist.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl x:Class="MyMusic.Wpf.Controls.Playlist"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MyMusic.Wpf.Controls" d:DataContext="{d:DesignInstance Type=local:Playlist}"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid x:Name="LayoutRoot">
+		<DataGrid AutoGenerateColumns="False" Grid.Row="1" Name="dgFiles" SelectedItem="{Binding CurrentTrack}" MouseDoubleClick="dgFiles_MouseDoubleClick" ItemsSource="{Binding Mp3Files}">
+			<DataGrid.Columns>
+				<DataGridTextColumn Header="Artist" Binding="{Binding DisplayArtist}" Width="*" IsReadOnly="True"/>
+				<DataGridTextColumn Header="Album" Binding="{Binding DisplayAlbum}" Width="*" IsReadOnly="True"/>
+				<DataGridTextColumn Header="Track" Binding="{Binding TrackNumber}" Width="40" IsReadOnly="True"/>
+				<DataGridTextColumn Header="Title" Binding="{Binding DisplayTitle}" Width="*" IsReadOnly="True"/>
+			</DataGrid.Columns>
+		</DataGrid>
+	</Grid>
+</UserControl>

--- a/MyMusic.Wpf/Controls/Playlist.xaml.cs
+++ b/MyMusic.Wpf/Controls/Playlist.xaml.cs
@@ -1,0 +1,79 @@
+﻿using MyMusic.Wpf.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MyMusic.Wpf.Controls
+{
+    /// <summary>
+    /// Interaction logic for Playlist.xaml
+    /// </summary>
+    public partial class Playlist : UserControl
+    {
+        
+        public Playlist()
+        {
+            InitializeComponent();
+            LayoutRoot.DataContext = this;
+        }
+
+        /// <summary>
+        /// Occurs when [MP3 file selected].
+        /// </summary>
+        public event Action<Mp3File> Mp3FileSelected;
+
+        /// <summary>
+        /// Gets or sets the list of MP3 files.
+        /// </summary>
+        /// <value>
+        /// The MP3 files.
+        /// </value>
+        public IEnumerable<Mp3File> Mp3Files
+        {
+            get { return (IEnumerable<Mp3File>)GetValue(Mp3FilesProperty); }
+            set { SetValue(Mp3FilesProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for MyProperty.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty Mp3FilesProperty =
+            DependencyProperty.Register("Mp3Files", typeof(IEnumerable<Mp3File>), typeof(Playlist), new PropertyMetadata(null));
+
+
+
+        /// <summary>
+        /// Gets or sets the current track.
+        /// </summary>
+        /// <value>
+        /// The current track.
+        /// </value>
+        public Mp3File CurrentTrack
+        {
+            get { return (Mp3File)GetValue(CurrentTrackProperty); }
+            set { SetValue(CurrentTrackProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for CurrentTrack.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty CurrentTrackProperty =
+            DependencyProperty.Register("CurrentTrack", typeof(Mp3File), typeof(Playlist), new PropertyMetadata(null));
+
+
+        // When the user double clicks on the data grid, this will further triggers the Mp3FileSelected event to notify its subscriber.
+        private void dgFiles_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var grid = sender as DataGrid;
+            var mp3file = grid.CurrentItem as Mp3File;
+            Mp3FileSelected?.Invoke(mp3file);
+        }
+    }
+}

--- a/MyMusic.Wpf/MainWindow.xaml
+++ b/MyMusic.Wpf/MainWindow.xaml
@@ -17,11 +17,11 @@
         </Grid.RowDefinitions>
 
         <TabControl Grid.Row="1">
-            <TabItem Header="Now Playing">
-                <controls:Player x:Name="player"/>
-            </TabItem>
+			<TabItem Header="Now Playing">
+				<controls:Player x:Name="player"/>
+			</TabItem>
 
-            <TabItem Header="All Files">
+			<TabItem Header="All Files">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -33,15 +33,8 @@
                             <Button Click="btnRebuild_Click" Name="btnRebuild">Rebuild</Button>
                         </StackPanel>
                     </ToolBar>
-
-                    <DataGrid AutoGenerateColumns="False" Grid.Row="1" Name="dgFiles" MouseDoubleClick="dgFiles_MouseDoubleClick" ItemsSource="{Binding AllFiles}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Artist" Binding="{Binding DisplayArtist}" Width="*" IsReadOnly="True"/>
-                            <DataGridTextColumn Header="Album" Binding="{Binding DisplayAlbum}" Width="*" IsReadOnly="True"/>
-                            <DataGridTextColumn Header="Track" Binding="{Binding TrackNumber}" Width="40" IsReadOnly="True"/>
-                            <DataGridTextColumn Header="Title" Binding="{Binding DisplayTitle}" Width="*" IsReadOnly="True"/>
-                        </DataGrid.Columns>
-                    </DataGrid>
+					<controls:Playlist x:Name="dgFiles" Grid.Row="1" Mp3FileSelected="dgFiles_Mp3FileSelected" Mp3Files="{Binding AllFiles}"/>
+				
                 </Grid>
             </TabItem>
         </TabControl>

--- a/MyMusic.Wpf/MainWindow.xaml.cs
+++ b/MyMusic.Wpf/MainWindow.xaml.cs
@@ -25,18 +25,16 @@ namespace MyMusic.Wpf
             DataContext = model;
         }
 
-        private void dgFiles_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            var grid = sender as DataGrid;
-            var mp3file = grid.CurrentItem as Mp3File;
-            player.PlayNow(mp3file);
-        }
-
         private async void btnRebuild_Click(object sender, RoutedEventArgs e)
         {
             var model = this.DataContext as Mp3View;
             model.AllFiles = await _cache.GetMp3FilesAsync(rebuild: true);
             model.LoadTime = _cache.ScanTime;
+        }
+
+        private void dgFiles_Mp3FileSelected(Mp3File mp3file)
+        {
+            player.PlayNow(mp3file);
         }
     }
 }

--- a/MyMusic.Wpf/Models/Mp3View.cs
+++ b/MyMusic.Wpf/Models/Mp3View.cs
@@ -1,11 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace MyMusic.Wpf.Models
 {
-    public class Mp3View
+    public class Mp3View : INotifyPropertyChanged
     {
-        public IEnumerable<Mp3File> AllFiles { get; set; }
+        private IEnumerable<Mp3File> _allFiles;
+        public IEnumerable<Mp3File> AllFiles
+        {
+            get => _allFiles; 
+            set
+            {
+                _allFiles = value;
+                NotifyOnProperyChanged();
+            }
+        }
+
         public TimeSpan LoadTime { get; set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void NotifyOnProperyChanged([CallerMemberName]string propName=null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
+        }
     }
 }


### PR DESCRIPTION
- Extracted the grid to new user control.
- Embedded it to the mainwindow where the grid was previously used.
- Embedded it to the player user control and bound the Playlist collection.

Related issue: #1 